### PR TITLE
1位ボーナスでステータスが1500を超えないように修正

### DIFF
--- a/src/views/EvaluationCalculator/lib/evaluate.ts
+++ b/src/views/EvaluationCalculator/lib/evaluate.ts
@@ -69,7 +69,9 @@ export const calculateRankWithScore = (
   const positionPoints = POSITION_POINTS[position];
   const statusSum =
     position === 1
-      ? vocal + 30 + (dance + 30) + (visual + 30)
+      ? Math.min(vocal + 30, 1500) +
+        Math.min(dance + 30, 1500) +
+        Math.min(visual + 30, 1500)
       : vocal + dance + visual;
 
   const statusPoints = Math.floor(statusSum * STATUS_MULTIPLIER);


### PR DESCRIPTION
# 内容
1位の+30ボーナスが加算される際、ステータスが1500を超えるようになっていたので修正しました。

お手数ですが、ご確認よろしくお願いします。